### PR TITLE
Cherry-pick of upstream fix: Multiple DNS-related fixes and improvements for docker::run and docker::service

### DIFF
--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -54,6 +54,10 @@
 #   Custom dns server address
 #   Defaults to undefined
 #
+# [*dns_search*]
+#   Custom dns search domains
+#   Defaults to undefined
+#
 # [*socket_group*]
 #   Group ownership of the unix control socket.
 #   Defaults to undefined
@@ -98,6 +102,7 @@ class docker(
   $tmp_dir                     = $docker::params::tmp_dir,
   $manage_kernel               = $docker::params::manage_kernel,
   $dns                         = $docker::params::dns,
+  $dns_search                  = $docker::params::dns_search,
   $socket_group                = $docker::params::socket_group,
   $extra_parameters            = undef,
   $proxy                       = $docker::params::proxy,

--- a/manifests/params.pp
+++ b/manifests/params.pp
@@ -1,6 +1,6 @@
 # == Class: docker::params
 #
-# Defaut parameter values for the docker module
+# Default parameter values for the docker module
 #
 class docker::params {
   $version                      = undef
@@ -14,6 +14,7 @@ class docker::params {
   $root_dir                     = undef
   $tmp_dir                      = '/tmp/'
   $dns                          = undef
+  $dns_search                   = undef
   $proxy                        = undef
   $no_proxy                     = undef
   $execdriver                   = undef

--- a/manifests/run.pp
+++ b/manifests/run.pp
@@ -18,6 +18,7 @@ define docker::run(
   $hostname = false,
   $env = [],
   $dns = [],
+  $dns_search = [],
   $lxc_conf = [],
   $restart_service = true,
   $disable_network = false,
@@ -52,6 +53,7 @@ define docker::run(
   $volumes_array = any2array($volumes)
   $env_array = any2array($env)
   $dns_array = any2array($dns)
+  $dns_search_array = any2array($dns_search)
   $links_array = any2array($links)
   $lxc_conf_array = any2array($lxc_conf)
   $extra_parameters_array = any2array($extra_parameters)

--- a/manifests/service.pp
+++ b/manifests/service.pp
@@ -25,6 +25,7 @@ class docker::service (
   $socket_bind          = $docker::socket_bind,
   $socket_group         = $docker::socket_group,
   $dns                  = $docker::dns,
+  $dns_search           = $docker::dns_search,
   $service_state        = $docker::service_state,
   $service_enable       = $docker::service_enable,
   $root_dir             = $docker::root_dir,
@@ -36,6 +37,7 @@ class docker::service (
   $tmp_dir              = $docker::tmp_dir,
 ) {
   $dns_array = any2array($dns)
+  $dns_search_array = any2array($dns_search)
   $extra_parameters_array = any2array($extra_parameters)
 
   case $::osfamily {

--- a/manifests/service.pp
+++ b/manifests/service.pp
@@ -24,6 +24,7 @@ class docker::service (
   $tcp_bind             = $docker::tcp_bind,
   $socket_bind          = $docker::socket_bind,
   $socket_group         = $docker::socket_group,
+  $dns                  = $docker::dns,
   $service_state        = $docker::service_state,
   $service_enable       = $docker::service_enable,
   $root_dir             = $docker::root_dir,
@@ -33,7 +34,8 @@ class docker::service (
   $execdriver           = $docker::execdriver,
   $storage_driver       = $docker::storage_driver,
   $tmp_dir              = $docker::tmp_dir,
-){
+) {
+  $dns_array = any2array($dns)
   $extra_parameters_array = any2array($extra_parameters)
 
   case $::osfamily {

--- a/spec/classes/docker_spec.rb
+++ b/spec/classes/docker_spec.rb
@@ -158,6 +158,16 @@ describe 'docker', :type => :class do
         it { should contain_file(service_config_file).with_content(/--dns 8.8.8.8/) }
       end
 
+      context 'with multi dns_search param' do
+        let(:params) { {'dns_search' => ['my.domain.local', 'other-domain.de']} }
+        it { should contain_file(service_config_file).with_content(/--dns-search my.domain.local/).with_content(/--dns-search other-domain.de/) }
+      end
+
+      context 'with dns_search param' do
+        let(:params) { {'dns_search' => 'my.domain.local'} }
+        it { should contain_file(service_config_file).with_content(/--dns-search my.domain.local/) }
+      end
+
       context 'with multi extra parameters' do
         let(:params) { {'extra_parameters' => ['--this this', '--that that'] } }
         it { should contain_file(service_config_file).with_content(/--this this/) }

--- a/spec/classes/docker_spec.rb
+++ b/spec/classes/docker_spec.rb
@@ -148,6 +148,16 @@ describe 'docker', :type => :class do
         it { should_not contain_file(service_config_file).with_content(/-e native/) }
       end
 
+      context 'with multi dns param' do
+        let(:params) { {'dns' => ['8.8.8.8', '8.8.4.4']} }
+        it { should contain_file(service_config_file).with_content(/--dns 8.8.8.8/).with_content(/--dns 8.8.4.4/) }
+      end
+
+      context 'with dns param' do
+        let(:params) { {'dns' => '8.8.8.8'} }
+        it { should contain_file(service_config_file).with_content(/--dns 8.8.8.8/) }
+      end
+
       context 'with multi extra parameters' do
         let(:params) { {'extra_parameters' => ['--this this', '--that that'] } }
         it { should contain_file(service_config_file).with_content(/--this this/) }

--- a/spec/defines/run_spec.rb
+++ b/spec/defines/run_spec.rb
@@ -121,6 +121,16 @@ require 'spec_helper'
       it { should contain_file(initscript).with_content(/--dns 8.8.8.8/) }
     end
 
+    context 'when passing serveral dns search domains' do
+      let(:params) { {'command' => 'command', 'image' => 'base', 'dns_search' => ['my.domain.local', 'other-domain.de']} }
+      it { should contain_file(initscript).with_content(/--dns-search my.domain.local/).with_content(/--dns-search other-domain.de/) }
+    end
+
+    context 'when passing a dns search domain' do
+      let(:params) { {'command' => 'command', 'image' => 'base', 'dns_search' => 'my.domain.local'} }
+      it { should contain_file(initscript).with_content(/--dns-search my.domain.local/) }
+    end
+
     context 'when disabling network' do
       let(:params) { {'command' => 'command', 'image' => 'base', 'disable_network' => true} }
       it { should contain_file(initscript).with_content(/-n false/) }

--- a/templates/etc/conf.d/docker.erb
+++ b/templates/etc/conf.d/docker.erb
@@ -3,7 +3,7 @@
 
 DOCKER="/usr/bin/<%= @docker_command %>"
 
-other_args="<% if @root_dir %>-g <%= @root_dir %><% end %> <% if @tcp_bind %>-H <%= @tcp_bind %><% end %><% if @socket_bind %> -H <%= @socket_bind %><% end %> <% if @socket_group %> -G <%= @socket_group %><% end %> <% if @execdriver %> -e <%= @execdriver %> <% end %> <% if @storage_driver %> --storage-driver=<%= @storage_driver %><% end %> <% if @extra_parameters %><% @extra_parameters_array.each do |param| %> <%= param %><% end %><% end %>"
+other_args="<% if @root_dir %>-g <%= @root_dir %><% end %> <% if @tcp_bind %>-H <%= @tcp_bind %><% end %><% if @socket_bind %> -H <%= @socket_bind %><% end %> <% if @socket_group %> -G <%= @socket_group %><% end %> <% if @dns %><% @dns_array.each do |address| %> --dns <%= address %><% end %><% end %> <% if @execdriver %> -e <%= @execdriver %> <% end %> <% if @storage_driver %> --storage-driver=<%= @storage_driver %><% end %> <% if @extra_parameters %><% @extra_parameters_array.each do |param| %> <%= param %><% end %><% end %>"
 <% if @proxy %>export http_proxy='<%= @proxy %>'
 export https_proxy='<%= @proxy %>'<% end %>
 <% if @no_proxy %>export no_proxy='<%= @no_proxy %>'<% end %>

--- a/templates/etc/conf.d/docker.erb
+++ b/templates/etc/conf.d/docker.erb
@@ -3,7 +3,16 @@
 
 DOCKER="/usr/bin/<%= @docker_command %>"
 
-other_args="<% if @root_dir %>-g <%= @root_dir %><% end %> <% if @tcp_bind %>-H <%= @tcp_bind %><% end %><% if @socket_bind %> -H <%= @socket_bind %><% end %> <% if @socket_group %> -G <%= @socket_group %><% end %> <% if @dns %><% @dns_array.each do |address| %> --dns <%= address %><% end %><% end %> <% if @execdriver %> -e <%= @execdriver %> <% end %> <% if @storage_driver %> --storage-driver=<%= @storage_driver %><% end %> <% if @extra_parameters %><% @extra_parameters_array.each do |param| %> <%= param %><% end %><% end %>"
+other_args="<% -%>
+<% if @root_dir %> -g <%= @root_dir %><% end -%>
+<% if @tcp_bind %> -H <%= @tcp_bind %><% end -%>
+<% if @socket_bind %> -H <%= @socket_bind %><% end -%>
+<% if @socket_group %> -G <%= @socket_group %><% end -%>
+<% if @dns %><% @dns_array.each do |address| %> --dns <%= address %><% end %><% end -%>
+<% if @execdriver %> -e <%= @execdriver %> <% end -%>
+<% if @storage_driver %> --storage-driver=<%= @storage_driver %><% end -%>
+<% if @extra_parameters %><% @extra_parameters_array.each do |param| %> <%= param %><% end %><% end -%>
+"
 <% if @proxy %>export http_proxy='<%= @proxy %>'
 export https_proxy='<%= @proxy %>'<% end %>
 <% if @no_proxy %>export no_proxy='<%= @no_proxy %>'<% end %>

--- a/templates/etc/conf.d/docker.erb
+++ b/templates/etc/conf.d/docker.erb
@@ -9,6 +9,7 @@ other_args="<% -%>
 <% if @socket_bind %> -H <%= @socket_bind %><% end -%>
 <% if @socket_group %> -G <%= @socket_group %><% end -%>
 <% if @dns %><% @dns_array.each do |address| %> --dns <%= address %><% end %><% end -%>
+<% if @dns_search %><% @dns_search_array.each do |domain| %> --dns-search <%= domain %><% end %><% end -%>
 <% if @execdriver %> -e <%= @execdriver %> <% end -%>
 <% if @storage_driver %> --storage-driver=<%= @storage_driver %><% end -%>
 <% if @extra_parameters %><% @extra_parameters_array.each do |param| %> <%= param %><% end %><% end -%>

--- a/templates/etc/default/docker.erb
+++ b/templates/etc/default/docker.erb
@@ -19,12 +19,12 @@ export TMPDIR="<%= @tmp_dir %>"
 
 # # Use DOCKER_OPTS to modify the daemon startup options.
 DOCKER_OPTS="\
-<% if @root_dir %>-g <%= @root_dir %> <% end -%>
-<% if @execdriver %>-e <%= @execdriver %> <% end -%>
-<% if @storage_driver %>--storage-driver=<%= @storage_driver %> <% end -%>
-<% if @tcp_bind %>-H <%= @tcp_bind %> <% end -%>
-<% if @socket_bind %> -H <%= @socket_bind %> <% end -%>
-<% if @socket_group %> -G <%= @socket_group %> <% end -%>
-<% if @dns %> --dns <%= @dns %> <% end -%>
-<% if @extra_parameters %><% @extra_parameters_array.each do |param| %> <%= param %> <% end %><% end -%>
+<% if @root_dir %> -g <%= @root_dir %><% end -%>
+<% if @tcp_bind %> -H <%= @tcp_bind %><% end -%>
+<% if @socket_bind %> -H <%= @socket_bind %><% end -%>
+<% if @socket_group %> -G <%= @socket_group %><% end -%>
+<% if @dns %><% @dns_array.each do |address| %> --dns <%= address %><% end %><% end -%>
+<% if @execdriver %> -e <%= @execdriver %> <% end -%>
+<% if @storage_driver %> --storage-driver=<%= @storage_driver %><% end -%>
+<% if @extra_parameters %><% @extra_parameters_array.each do |param| %> <%= param %><% end %><% end -%>
 "

--- a/templates/etc/default/docker.erb
+++ b/templates/etc/default/docker.erb
@@ -24,6 +24,7 @@ DOCKER_OPTS="\
 <% if @socket_bind %> -H <%= @socket_bind %><% end -%>
 <% if @socket_group %> -G <%= @socket_group %><% end -%>
 <% if @dns %><% @dns_array.each do |address| %> --dns <%= address %><% end %><% end -%>
+<% if @dns_search %><% @dns_search_array.each do |domain| %> --dns-search <%= domain %><% end %><% end -%>
 <% if @execdriver %> -e <%= @execdriver %> <% end -%>
 <% if @storage_driver %> --storage-driver=<%= @storage_driver %><% end -%>
 <% if @extra_parameters %><% @extra_parameters_array.each do |param| %> <%= param %><% end %><% end -%>

--- a/templates/etc/init.d/docker-run.erb
+++ b/templates/etc/init.d/docker-run.erb
@@ -57,6 +57,9 @@ start() {
         <% if @dns %><% @dns_array.each do |address| %> \
             --dns <%= address %><% end %> \
         <% end %> \
+        <% if @dns_search %><% @dns_search_array.each do |domain| %> \
+            --dns-search <%= domain %><% end %> \
+        <% end %> \
         <% if @env %><% @env_array.each do |env| %> \
             -e <%= env %><% end %> \
         <% end %> \

--- a/templates/etc/init/docker-run.conf.erb
+++ b/templates/etc/init/docker-run.conf.erb
@@ -21,6 +21,9 @@ script
     <% if @dns %><% @dns_array.each do |address| %> \
         --dns <%= address %><% end %> \
     <% end %> \
+    <% if @dns_search %><% @dns_search_array.each do |domain| %> \
+        --dns-search <%= domain %><% end %> \
+    <% end %> \
     <% if @env %><% @env_array.each do |env| %> \
         -e <%= env %><% end %> \
     <% end %> \
@@ -59,6 +62,9 @@ script
     <% if @privileged %>--privileged<% end %> \
     <% if @dns %><% @dns_array.each do |address| %> \
         --dns <%= address %><% end %> \
+    <% end %> \
+    <% if @dns_search %><% @dns_search_array.each do |domain| %> \
+        --dns-search <%= domain %><% end %> \
     <% end %> \
     <% if @env %><% @env_array.each do |env| %> \
         -e <%= env %><% end %> \

--- a/templates/etc/sysconfig/docker.erb
+++ b/templates/etc/sysconfig/docker.erb
@@ -3,7 +3,7 @@
 
 DOCKER="/usr/bin/<%= @docker_command %>"
 
-other_args="<% if @root_dir %>-g <%= @root_dir %><% end %> <% if @tcp_bind %>-H <%= @tcp_bind %><% end %><% if @socket_bind %> -H <%= @socket_bind %><% end %> <% if @socket_group %> -G <%= @socket_group %><% end %> <% if @execdriver %> -e <%= @execdriver %> <% end %> <% if @storage_driver %> --storage-driver=<%= @storage_driver %><% end %> <% if @extra_parameters %><% @extra_parameters_array.each do |param| %> <%= param %><% end %><% end %>"
+other_args="<% if @root_dir %>-g <%= @root_dir %><% end %> <% if @tcp_bind %>-H <%= @tcp_bind %><% end %><% if @socket_bind %> -H <%= @socket_bind %><% end %> <% if @socket_group %> -G <%= @socket_group %><% end %> <% if @dns %><% @dns_array.each do |address| %> --dns <%= address %><% end %><% end %> <% if @execdriver %> -e <%= @execdriver %> <% end %> <% if @storage_driver %> --storage-driver=<%= @storage_driver %><% end %> <% if @extra_parameters %><% @extra_parameters_array.each do |param| %> <%= param %><% end %><% end %>"
 <% if @proxy %>export http_proxy='<%= @proxy %>'
 export https_proxy='<%= @proxy %>'<% end %>
 <% if @no_proxy %>export no_proxy='<%= @no_proxy %>'<% end %>

--- a/templates/etc/sysconfig/docker.erb
+++ b/templates/etc/sysconfig/docker.erb
@@ -3,7 +3,16 @@
 
 DOCKER="/usr/bin/<%= @docker_command %>"
 
-other_args="<% if @root_dir %>-g <%= @root_dir %><% end %> <% if @tcp_bind %>-H <%= @tcp_bind %><% end %><% if @socket_bind %> -H <%= @socket_bind %><% end %> <% if @socket_group %> -G <%= @socket_group %><% end %> <% if @dns %><% @dns_array.each do |address| %> --dns <%= address %><% end %><% end %> <% if @execdriver %> -e <%= @execdriver %> <% end %> <% if @storage_driver %> --storage-driver=<%= @storage_driver %><% end %> <% if @extra_parameters %><% @extra_parameters_array.each do |param| %> <%= param %><% end %><% end %>"
+other_args="<% -%>
+<% if @root_dir %> -g <%= @root_dir %><% end -%>
+<% if @tcp_bind %> -H <%= @tcp_bind %><% end -%>
+<% if @socket_bind %> -H <%= @socket_bind %><% end -%>
+<% if @socket_group %> -G <%= @socket_group %><% end -%>
+<% if @dns %><% @dns_array.each do |address| %> --dns <%= address %><% end %><% end -%>
+<% if @execdriver %> -e <%= @execdriver %> <% end -%>
+<% if @storage_driver %> --storage-driver=<%= @storage_driver %><% end -%>
+<% if @extra_parameters %><% @extra_parameters_array.each do |param| %> <%= param %><% end %><% end -%>
+"
 <% if @proxy %>export http_proxy='<%= @proxy %>'
 export https_proxy='<%= @proxy %>'<% end %>
 <% if @no_proxy %>export no_proxy='<%= @no_proxy %>'<% end %>

--- a/templates/etc/sysconfig/docker.erb
+++ b/templates/etc/sysconfig/docker.erb
@@ -9,6 +9,7 @@ other_args="<% -%>
 <% if @socket_bind %> -H <%= @socket_bind %><% end -%>
 <% if @socket_group %> -G <%= @socket_group %><% end -%>
 <% if @dns %><% @dns_array.each do |address| %> --dns <%= address %><% end %><% end -%>
+<% if @dns_search %><% @dns_search_array.each do |domain| %> --dns-search <%= domain %><% end %><% end -%>
 <% if @execdriver %> -e <%= @execdriver %> <% end -%>
 <% if @storage_driver %> --storage-driver=<%= @storage_driver %><% end -%>
 <% if @extra_parameters %><% @extra_parameters_array.each do |param| %> <%= param %><% end %><% end -%>

--- a/templates/etc/systemd/system/docker-run.erb
+++ b/templates/etc/systemd/system/docker-run.erb
@@ -20,6 +20,9 @@ ExecStart=/usr/bin/<%= @docker_command %> run \
         <% if @dns %><% @dns_array.each do |address| %> \
             --dns <%= address %><% end %> \
         <% end %> \
+        <% if @dns_search %><% @dns_search_array.each do |domain| %> \
+            --dns-search <%= domain %><% end %> \
+        <% end %> \
         <% if @env %><% @env_array.each do |env| %> \
             -e <%= env %><% end %> \
         <% end %> \


### PR DESCRIPTION
Upstream changes as seen in https://github.com/garethr/garethr-docker/pull/146:
Fixed handling of $docker::dns: One can specify that parameter, but the value was not actually included in the different configuration files. The parameter was added to docker::service, and the three templates were modified to include it. Unit tests were added to prevent regressions.

Added a $docker::run::dns_search parameter: Modified docker::run and the corresponding templates. Also includes unit tests.

Cleaned up and unified the formatting of the configuration templates.

Added a $docker::dns_search parameter: Like above, but for the docker daemon instead of individual containers. Includes unit tests.
