### PR TITLE
support restart of dependent services

### DIFF
--- a/manifests/run.pp
+++ b/manifests/run.pp
@@ -29,7 +29,8 @@ define docker::run(
   $pre_start = undef,
   $post_start = undef,
   $pre_stop = undef,
-  $post_stop = undef
+  $post_stop = undef,
+  $trigger_restart = undef
 ) {
   include docker::params
   $docker_command = $docker::params::docker_command
@@ -64,6 +65,7 @@ define docker::run(
   $links_array = any2array($links)
   $lxc_conf_array = any2array($lxc_conf)
   $extra_parameters_array = any2array($extra_parameters)
+  $trigger_restart_array = any2array($trigger_restart)
 
   $sanitised_title = regsubst($title, '[^0-9A-Za-z.\-]', '-', 'G')
   $sanitised_image = regsubst($image, '[^0-9A-Za-z.\-]', '-', 'G')

--- a/templates/etc/init/docker-run.conf.erb
+++ b/templates/etc/init/docker-run.conf.erb
@@ -37,6 +37,9 @@ post-start script
 	 NAME="<%= @name %>" \
          <%= @post_start %>
    <% end -%>
+   <% @trigger_restart_array.each do |image| -%>
+   service docker-<%= image %> restart
+   <% end -%>
    true
 end script
 


### PR DESCRIPTION
Jag har ofta problem med pound->varnish->foo eftersom pound inte resolvar namnet på sin backend mer än vid start. Det vore trevligt att kunna tala om för varnish att göra "service docker-pound restart" vid start (och tala om för foo att starta-om varnish vid start)
